### PR TITLE
update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### 0.10.0
 
 #### TUI Features
-- **Bash Mode**: Added Bash mode (!) to run shell commands directly in chat and see output in transcript
 - **Session Switching**: Added `/sessions` command to switch between sessions without restarting CLI
 - **Shell Configuration**: Added `/config` command to configure default shell and startup script
 - **Keyboard Shortcuts**: Added Ctrl+/ for undo and Ctrl+Y for redo in normal edit mode
@@ -15,9 +14,6 @@
 - Support resuming sessions by ID prefix (unambiguous matches)
 - Added `-f` flag to filter session list to current workspace only
 - Reversed session list order to show newest sessions first
-
-#### Hooks System
-- Integrated hooks system into CLI/TUI for tool execution and session lifecycle events
 
 #### UI Improvements
 - Fixed text wrapping in tool result summaries


### PR DESCRIPTION
Remove unreleased features from 0.10.0 changelog

This PR removes two features from the 0.10.0 changelog that are not yet ready for release:

- **Bash Mode**: Removed the Bash mode (!) feature for running shell commands directly in chat
- **Hooks System**: Removed the hooks system integration for tool execution and session lifecycle events

These features will be added back to the changelog when they are ready for release.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*

<h2></h2>

<details>
<summary><b>🤖 Augment PR Description</b></summary>

<br>

<b>Summary:</b> Updates the 0.10.0 CHANGELOG to remove unreleased features.

<b>Changes:</b> Removes entries for "Bash Mode" and the "Hooks System" section to reflect what will actually ship.

<sub>🤖 Was this summary useful? React with 👍 or 👎</sub>
</details>