### PR TITLE
Improve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Learn more in the Augment Docs:
 1. Install Auggie (Node 22+ required):
 
 ```sh
-npm install -g @augmentcode/auggie
+npm install -g @augmentcode/auggie@latest
 ```
 
 2. Login:

--- a/examples/typescript-sdk/context/README.md
+++ b/examples/typescript-sdk/context/README.md
@@ -7,7 +7,7 @@ Examples demonstrating the Auggie SDK's context modes and AI-powered code analys
 1. **Node.js 18+** - Required to run the examples
 2. **Auggie CLI** - Required for FileSystem Context examples
    ```bash
-   npm install -g @augmentcode/auggie
+   npm install -g @augmentcode/auggie@latest
    ```
 3. **Authentication** - Required for all examples
    ```bash

--- a/examples/typescript-sdk/context/file-search-server/README.md
+++ b/examples/typescript-sdk/context/file-search-server/README.md
@@ -6,7 +6,7 @@ REST API for semantic file search with AI-powered summarization.
 
 Install the `auggie` CLI and authenticate:
 ```bash
-npm install -g @augmentcode/auggie
+npm install -g @augmentcode/auggie@latest
 auggie login
 ```
 

--- a/examples/typescript-sdk/context/github-action-indexer/README.md
+++ b/examples/typescript-sdk/context/github-action-indexer/README.md
@@ -65,15 +65,36 @@ The installation script will:
 
 ### 2. Configure Repository Secrets
 
-Add these secrets to your repository (Settings → Secrets and variables → Actions):
+In the GitHub UI, navigate to your repository **Settings → Secrets and variables → Actions** and add these secrets:
 
 | Secret Name | Description | Required |
 |-------------|-------------|----------|
-| `AUGMENT_API_TOKEN` | Your Augment API token (can be a JSON object with `accessToken` and `tenantURL` fields, or a plain token string) | Yes |
+| `AUGMENT_API_TOKEN` | Your Augment API token | Yes |
+| `AUGMENT_API_URL` | Your tenant-specific Augment API URL (e.g., `https://your-tenant.api.augmentcode.com/`) | Yes |
+
+**How to get your credentials:**
+
+1. **Using the Auggie CLI** (recommended):
+   ```bash
+   # Login to Augment
+   auggie login
+
+   # Print your credentials
+   auggie token print
+   ```
+
+   This outputs:
+   ```
+   TOKEN={"accessToken":"your-token-here","tenantURL":"https://your-tenant.api.augmentcode.com/","scopes":["read","write"]}
+   ```
+
+   Extract the values from the JSON:
+   - `accessToken` → use for `AUGMENT_API_TOKEN`
+   - `tenantURL` → use for `AUGMENT_API_URL`
+
+2. **From your Augment account**: Contact your Augment administrator or check your account settings for API credentials.
 
 **Note:**
-- If using a plain token string, you must also set `AUGMENT_API_URL` as a secret or environment variable
-- If your token is a JSON object from `~/.augment/session.json` (with `accessToken` and `tenantURL`), the URL will be extracted automatically
 - `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and `GITHUB_SHA` are automatically provided by GitHub Actions
 
 ### 3. Push and Run

--- a/examples/typescript-sdk/context/github-action-indexer/install.js
+++ b/examples/typescript-sdk/context/github-action-indexer/install.js
@@ -209,6 +209,7 @@ jobs:
         run: npm run index
         env:
           AUGMENT_API_TOKEN: \${{ secrets.AUGMENT_API_TOKEN }}
+          AUGMENT_API_URL: \${{ secrets.AUGMENT_API_URL }}
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           MAX_COMMITS: ${settings.maxCommits}
           MAX_FILES: ${settings.maxFiles}
@@ -264,6 +265,7 @@ jobs:
         run: npm run index
         env:
           AUGMENT_API_TOKEN: \${{ secrets.AUGMENT_API_TOKEN }}
+          AUGMENT_API_URL: \${{ secrets.AUGMENT_API_URL }}
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           MAX_COMMITS: ${settings.maxCommits}
           MAX_FILES: ${settings.maxFiles}

--- a/examples/typescript-sdk/context/github-action-indexer/src/index.ts
+++ b/examples/typescript-sdk/context/github-action-indexer/src/index.ts
@@ -8,40 +8,18 @@ import { IndexManager } from "./index-manager.js";
 import type { IndexConfig } from "./types.js";
 
 /**
- * Parse API token from environment variable
- * Handles both plain string tokens and JSON-formatted tokens
+ * Get API credentials from environment variables
  */
-function parseApiToken(): { apiToken: string; apiUrl: string } {
-  const apiTokenEnv = process.env.AUGMENT_API_TOKEN;
-  if (!apiTokenEnv) {
+function getApiCredentials(): { apiToken: string; apiUrl: string } {
+  const apiToken = process.env.AUGMENT_API_TOKEN;
+  if (!apiToken) {
     throw new Error("AUGMENT_API_TOKEN environment variable is required");
   }
 
-  let apiToken: string;
-  let apiUrl: string | undefined = process.env.AUGMENT_API_URL;
-
-  try {
-    const tokenObj = JSON.parse(apiTokenEnv) as {
-      accessToken?: string;
-      tenantURL?: string;
-    };
-    if (tokenObj.accessToken) {
-      apiToken = tokenObj.accessToken;
-      // Use tenantURL from token if not overridden by env var
-      if (!apiUrl && tokenObj.tenantURL) {
-        apiUrl = tokenObj.tenantURL;
-      }
-    } else {
-      apiToken = apiTokenEnv;
-    }
-  } catch {
-    // Not JSON, use as-is
-    apiToken = apiTokenEnv;
-  }
-
+  const apiUrl = process.env.AUGMENT_API_URL;
   if (!apiUrl) {
     throw new Error(
-      "AUGMENT_API_URL environment variable is required. Please set it to your tenant-specific URL (e.g., 'https://your-tenant.api.augmentcode.com') or include tenantURL in your API token JSON."
+      "AUGMENT_API_URL environment variable is required. Please set it to your tenant-specific URL (e.g., 'https://your-tenant.api.augmentcode.com/')"
     );
   }
 
@@ -96,7 +74,7 @@ function loadConfig(): IndexConfig {
     throw new Error("GITHUB_TOKEN environment variable is required");
   }
 
-  const { apiToken, apiUrl } = parseApiToken();
+  const { apiToken, apiUrl } = getApiCredentials();
   const { owner, repo, branch, currentCommit } = parseRepositoryInfo();
 
   return {

--- a/examples/typescript-sdk/context/github-action-indexer/src/search.ts
+++ b/examples/typescript-sdk/context/github-action-indexer/src/search.ts
@@ -73,39 +73,17 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Get API token
-  const apiTokenEnv = process.env.AUGMENT_API_TOKEN;
-  if (!apiTokenEnv) {
+  // Get API credentials
+  const apiToken = process.env.AUGMENT_API_TOKEN;
+  if (!apiToken) {
     console.error("Error: AUGMENT_API_TOKEN environment variable is required");
     process.exit(1);
   }
 
-  // Parse API token - it can be either a JSON object or a plain string
-  let apiToken: string;
-  let apiUrl: string | undefined = process.env.AUGMENT_API_URL;
-
-  try {
-    const tokenObj = JSON.parse(apiTokenEnv) as {
-      accessToken?: string;
-      tenantURL?: string;
-    };
-    if (tokenObj.accessToken) {
-      apiToken = tokenObj.accessToken;
-      // Use tenantURL from token if not overridden by env var
-      if (!apiUrl && tokenObj.tenantURL) {
-        apiUrl = tokenObj.tenantURL;
-      }
-    } else {
-      apiToken = apiTokenEnv;
-    }
-  } catch {
-    // Not JSON, use as-is
-    apiToken = apiTokenEnv;
-  }
-
+  const apiUrl = process.env.AUGMENT_API_URL;
   if (!apiUrl) {
     console.error(
-      "Error: AUGMENT_API_URL environment variable is required. Please set it to your tenant-specific URL (e.g., 'https://your-tenant.api.augmentcode.com') or include tenantURL in your API token JSON."
+      "Error: AUGMENT_API_URL environment variable is required. Please set it to your tenant-specific URL (e.g., 'https://your-tenant.api.augmentcode.com/')"
     );
     process.exit(1);
   }

--- a/examples/typescript-sdk/context/github-action-indexer/src/types.ts
+++ b/examples/typescript-sdk/context/github-action-indexer/src/types.ts
@@ -41,8 +41,7 @@ export type IndexConfig = {
 
   /**
    * Augment API URL
-   * Can be provided via AUGMENT_API_URL env var, or extracted from
-   * a JSON-formatted AUGMENT_API_TOKEN that includes tenantURL field
+   * Provided via AUGMENT_API_URL env var
    */
   apiUrl: string;
 

--- a/examples/typescript-sdk/context/prompt-enhancer-server/README.md
+++ b/examples/typescript-sdk/context/prompt-enhancer-server/README.md
@@ -6,7 +6,7 @@ HTTP server that enhances vague prompts using AI with codebase context.
 
 Install the `auggie` CLI and authenticate:
 ```bash
-npm install -g @augmentcode/auggie
+npm install -g @augmentcode/auggie@latest
 auggie login
 ```
 


### PR DESCRIPTION
Improve documentation and simplify authentication in TypeScript SDK examples.

## Changes

- **Standardize installation commands**: Add `@latest` tag to all `npm install -g @augmentcode/auggie` commands across README files to ensure users install the most recent version
- **Simplify API credential handling**: Remove JSON token parsing logic from GitHub Action Indexer examples, requiring explicit `AUGMENT_API_TOKEN` and `AUGMENT_API_URL` environment variables instead of supporting multiple token formats
- **Enhance setup documentation**: Add detailed instructions in the GitHub Action Indexer README for obtaining API credentials using `auggie token print`

## Impact

These changes make the examples more maintainable and reduce confusion by:
- Ensuring users always get the latest CLI version during installation
- Removing ambiguity around token format requirements
- Providing clearer guidance for credential setup

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*