### PR TITLE
Fixup github-action-indexer example

### DIFF
--- a/examples/typescript-sdk/context/github-action-indexer/.github/workflows/index.yml
+++ b/examples/typescript-sdk/context/github-action-indexer/.github/workflows/index.yml
@@ -52,6 +52,7 @@ jobs:
         run: npm run index
         env:
           AUGMENT_API_TOKEN: ${{ secrets.AUGMENT_API_TOKEN }}
+          AUGMENT_API_URL: ${{ secrets.AUGMENT_API_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STORAGE_TYPE: file
           # Branch-specific state path (automatically determined from GITHUB_REF)

--- a/examples/typescript-sdk/context/github-action-indexer/src/index-manager.ts
+++ b/examples/typescript-sdk/context/github-action-indexer/src/index-manager.ts
@@ -18,7 +18,7 @@ const DEFAULT_MAX_FILES = 500;
 
 export class IndexManager {
   private readonly github: GitHubClient;
-  private readonly context: DirectContext;
+  private context: DirectContext;
   private readonly config: IndexConfig;
   private readonly statePath: string;
 
@@ -373,7 +373,7 @@ export class IndexManager {
     try {
       // Create a new context from the previous state
       this.context = await DirectContext.importFromFile(tempStateFile, {
-        apiKey: this.config.apiKey,
+        apiKey: this.config.apiToken,
         apiUrl: this.config.apiUrl,
       });
     } finally {


### PR DESCRIPTION
Fix configuration and type issues in github-action-indexer example

This PR addresses three small but important issues in the github-action-indexer example:

- **Add missing `AUGMENT_API_URL` environment variable** to the GitHub Actions workflow, ensuring the indexer can connect to the correct API endpoint
- **Fix incorrect property reference** from `this.config.apiKey` to `this.config.apiToken` in the incremental update logic
- **Remove `readonly` modifier from `context` property** to allow reassignment when importing previous state during incremental updates

These fixes ensure the example works correctly for both full and incremental indexing scenarios.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*