### PR TITLE
Increase timeout for a unit test

### DIFF
--- a/examples/python-sdk/context/filesystem_context/test_example.py
+++ b/examples/python-sdk/context/filesystem_context/test_example.py
@@ -27,7 +27,7 @@ def main():
         [sys.executable, "-m", "filesystem_context"],
         capture_output=True,
         text=True,
-        timeout=120,  # 2 minutes should be plenty
+        timeout=300,  # 5 minutes - multiple LLM API calls via search_and_ask
         cwd=str(context_dir),
     )
 


### PR DESCRIPTION
Increase timeout for filesystem context test from 2 minutes to 5 minutes to accommodate multiple LLM API calls made during `search_and_ask` operations.

The previous 120-second timeout was insufficient for the test execution, which involves multiple sequential LLM API calls that can take longer than expected, especially under varying network conditions or API response times.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*