### PR TITLE
Add bun-compile GitHub Action workflow

### DIFF
--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -41,7 +41,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install package
-        run: bun install @augmentcode/auggie@${{ inputs.version || github.event.client_payload.version || '0.18.1' }}
+        env:
+          VERSION: ${{ inputs.version || github.event.client_payload.version }}
+        run: |
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version provided. Supply via workflow_dispatch input or repository_dispatch payload."
+            exit 1
+          fi
+          bun install "@augmentcode/auggie@${VERSION}"
 
       - name: Create entry point
         run: |
@@ -72,9 +79,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          VERSION: ${{ inputs.version || github.event.client_payload.version }}
         run: |
-          gh release create "v${{ inputs.version || github.event.client_payload.version || '0.18.1' }}" \
-            --title "v${{ inputs.version || github.event.client_payload.version || '0.18.1' }}" \
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version provided. Cannot create release."
+            exit 1
+          fi
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
             --generate-notes \
             artifacts/*
 

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -10,6 +10,9 @@ on:
         description: 'npm package version (e.g. 0.17.0)'
         required: true
         type: string
+  push:
+    branches:
+      - auggie-bun-compile-workflow
 
 jobs:
   build:
@@ -33,7 +36,7 @@ jobs:
 
       - name: Create entry point
         run: |
-          echo 'await import("npm:@augmentcode/auggie@${{ inputs.version }}");' > augment.mjs
+          echo 'await import("npm:@augmentcode/auggie@${{ inputs.version || '0.17.0-prerelease.14' }}");' > augment.mjs
 
       - name: Compile binary
         run: bun build augment.mjs --compile --target=${{ matrix.target }} --outfile=${{ matrix.output }}
@@ -61,8 +64,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release create "v${{ inputs.version }}" \
-            --title "v${{ inputs.version }}" \
+          gh release create "v${{ inputs.version || '0.17.0-prerelease.14' }}" \
+            --title "v${{ inputs.version || '0.17.0-prerelease.14' }}" \
             --generate-notes \
             artifacts/*
 

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -41,7 +41,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install package
-        run: bun install @augmentcode/auggie@${{ inputs.version || github.event.client_payload.version || '0.17.0-prerelease.14' }}
+        run: bun install @augmentcode/auggie@${{ inputs.version || github.event.client_payload.version || '0.18.1' }}
 
       - name: Create entry point
         run: |
@@ -73,8 +73,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release create "v${{ inputs.version || github.event.client_payload.version || '0.17.0-prerelease.14' }}" \
-            --title "v${{ inputs.version || github.event.client_payload.version || '0.17.0-prerelease.14' }}" \
+          gh release create "v${{ inputs.version || github.event.client_payload.version || '0.18.1' }}" \
+            --title "v${{ inputs.version || github.event.client_payload.version || '0.18.1' }}" \
             --generate-notes \
             artifacts/*
 

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create entry point
         run: |
-          printf 'process.argv[1] = process.execPath;\nawait import("@augmentcode/auggie");\n' > augment.mjs
+          echo 'await import("@augmentcode/auggie");' > augment.mjs
 
       - name: Compile binary
         run: bun build augment.mjs --compile --target=${{ matrix.target }} --outfile=${{ matrix.output }}

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -34,9 +34,12 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
 
+      - name: Install package
+        run: bun install @augmentcode/auggie@${{ inputs.version || '0.17.0-prerelease.14' }}
+
       - name: Create entry point
         run: |
-          echo 'await import("npm:@augmentcode/auggie@${{ inputs.version || '0.17.0-prerelease.14' }}");' > augment.mjs
+          echo 'await import("@augmentcode/auggie");' > augment.mjs
 
       - name: Compile binary
         run: bun build augment.mjs --compile --target=${{ matrix.target }} --outfile=${{ matrix.output }}

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -1,0 +1,68 @@
+# Bun Compile
+# Compiles Auggie CLI into self-contained native binaries using Bun,
+# pulling the pre-built @augmentcode/auggie package from npm.
+
+name: Bun Compile
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'npm package version (e.g. 0.17.0)'
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: bun-darwin-arm64
+            output: auggie-bun-darwin-arm64
+          - target: bun-darwin-x64
+            output: auggie-bun-darwin-x64
+          - target: bun-linux-x64
+            output: auggie-bun-linux-x64
+          - target: bun-windows-x64
+            output: auggie-bun-windows-x64.exe
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Create entry point
+        run: |
+          echo 'await import("npm:@augmentcode/auggie@${{ inputs.version }}");' > augment.mjs
+
+      - name: Compile binary
+        run: bun build augment.mjs --compile --target=${{ matrix.target }} --outfile=${{ matrix.output }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.output }}
+          path: ${{ matrix.output }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "v${{ inputs.version }}" \
+            --generate-notes \
+            artifacts/*
+

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create entry point
         run: |
-          echo 'await import("@augmentcode/auggie");' > augment.mjs
+          printf 'process.argv[1] = process.execPath;\nawait import("@augmentcode/auggie");\n' > augment.mjs
 
       - name: Compile binary
         run: bun build augment.mjs --compile --target=${{ matrix.target }} --outfile=${{ matrix.output }}

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -12,6 +12,9 @@ on:
         type: string
   repository_dispatch:
     types: [npm-published]
+  push:
+    branches:
+      - auggie-bun-compile-workflow
 
 jobs:
   build:
@@ -21,12 +24,16 @@ jobs:
         include:
           - target: bun-darwin-arm64
             output: auggie-darwin-arm64
+            artifact: auggie-darwin-arm64
           - target: bun-darwin-x64
             output: auggie-darwin-x64
+            artifact: auggie-darwin-x64
           - target: bun-linux-x64
             output: auggie-linux-x64
+            artifact: auggie-linux-x64
           - target: bun-windows-x64
             output: auggie-windows-x64.exe
+            artifact: auggie-windows-x64
     permissions:
       contents: read
     steps:
@@ -34,7 +41,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install package
-        run: bun install @augmentcode/auggie@${{ inputs.version || github.event.client_payload.version }}
+        run: bun install @augmentcode/auggie@${{ inputs.version || github.event.client_payload.version || '0.17.0-prerelease.14' }}
 
       - name: Create entry point
         run: |
@@ -46,7 +53,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: auggie-${{ matrix.target }}
+          name: ${{ matrix.artifact }}
           path: ${{ matrix.output }}
 
   release:
@@ -66,8 +73,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release create "v${{ inputs.version || github.event.client_payload.version }}" \
-            --title "v${{ inputs.version || github.event.client_payload.version }}" \
+          gh release create "v${{ inputs.version || github.event.client_payload.version || '0.17.0-prerelease.14' }}" \
+            --title "v${{ inputs.version || github.event.client_payload.version || '0.17.0-prerelease.14' }}" \
             --generate-notes \
             artifacts/*
 

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -20,13 +20,13 @@ jobs:
       matrix:
         include:
           - target: bun-darwin-arm64
-            output: auggie-bun-darwin-arm64
+            output: auggie-darwin-arm64
           - target: bun-darwin-x64
-            output: auggie-bun-darwin-x64
+            output: auggie-darwin-x64
           - target: bun-linux-x64
-            output: auggie-bun-linux-x64
+            output: auggie-linux-x64
           - target: bun-windows-x64
-            output: auggie-bun-windows-x64.exe
+            output: auggie-windows-x64.exe
     permissions:
       contents: read
     steps:

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.output }}
+          name: auggie-${{ matrix.target }}
           path: ${{ matrix.output }}
 
   release:

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -10,9 +10,8 @@ on:
         description: 'npm package version (e.g. 0.17.0)'
         required: true
         type: string
-  push:
-    branches:
-      - auggie-bun-compile-workflow
+  repository_dispatch:
+    types: [npm-published]
 
 jobs:
   build:
@@ -35,7 +34,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install package
-        run: bun install @augmentcode/auggie@${{ inputs.version || '0.17.0-prerelease.14' }}
+        run: bun install @augmentcode/auggie@${{ inputs.version || github.event.client_payload.version }}
 
       - name: Create entry point
         run: |
@@ -67,8 +66,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release create "v${{ inputs.version || '0.17.0-prerelease.14' }}" \
-            --title "v${{ inputs.version || '0.17.0-prerelease.14' }}" \
+          gh release create "v${{ inputs.version || github.event.client_payload.version }}" \
+            --title "v${{ inputs.version || github.event.client_payload.version }}" \
             --generate-notes \
             artifacts/*
 


### PR DESCRIPTION
Add a GitHub Actions workflow (`bun-compile.yml`) that cross-compiles the Auggie CLI into self-contained native binaries using Bun's `--compile` flag, pulling the pre-built `@augmentcode/auggie` package directly from npm.

- Trigger via `workflow_dispatch` with a required `version` input (the npm package version to compile)
- Cross-compile on `ubuntu-latest` for 4 platform targets using a build matrix: `darwin-arm64`, `darwin-x64`, `linux-x64`, `windows-x64`
- Upload each compiled binary as a GitHub Actions artifact
- Create a GitHub Release (in a separate `release` job) with auto-generated notes and all 4 binaries attached

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*