### PR TITLE
Add macOS code signing, notarization, and SHA-256 checksums to Bun compile workflow

### DIFF
--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -73,6 +73,7 @@ jobs:
           security unlock-keychain -p "temppass" build.keychain
           security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "temppass" build.keychain
+          rm -f certificate.p12
 
       - name: Sign binary
         if: contains(matrix.target, 'darwin')
@@ -83,7 +84,7 @@ jobs:
             exit 1
           fi
           echo "Signing with identity: $IDENTITY"
-          codesign --force --options runtime --sign "$IDENTITY" ${{ matrix.output }}
+          codesign --force --options runtime --timestamp --sign "$IDENTITY" ${{ matrix.output }}
 
       - name: Notarize binary
         if: contains(matrix.target, 'darwin')
@@ -94,6 +95,7 @@ jobs:
         run: |
           zip "${{ matrix.output }}.zip" "${{ matrix.output }}"
           xcrun notarytool submit "${{ matrix.output }}.zip" --apple-id "$APPLE_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+          rm -f "${{ matrix.output }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Adds macOS code signing, notarization, and SHA-256 release checksums to the Bun compile workflow.

## Tested

✅ Full workflow tested end-to-end. Downloaded macOS binaries can be run directly without needing to resolve Apple quarantine (`xattr -d com.apple.quarantine`) first — Gatekeeper recognizes the notarization ticket automatically.

## Changes

- **Matrix OS split**: macOS targets now build on `macos-latest` (required for `codesign`/`notarytool`); Linux/Windows stay on `ubuntu-latest`
- **Code signing**: Imports Developer ID Application certificate, signs with `codesign --force --options runtime` (hardened runtime required for notarization)
- **Notarization**: Submits signed binary to Apple via `xcrun notarytool submit --wait`
- **Checksums**: Generates `checksums.txt` with SHA-256 hashes of all release binaries, included automatically in the GitHub Release

## Secrets Required

All 5 secrets are already configured in the repo:
- `APPLE_CERTIFICATE` — base64-encoded .p12
- `APPLE_CERTIFICATE_PASSWORD` — .p12 password
- `APPLE_ID` — Apple ID email
- `APPLE_APP_SPECIFIC_PASSWORD` — app-specific password for notarytool
- `APPLE_TEAM_ID` — Apple Developer Team ID

## Notes

- Staple is not supported for standalone binaries — Gatekeeper checks the notarization ticket online on first launch
- The codesign identity is auto-detected from the imported certificate
- Non-macOS build behavior is unchanged