### PR TITLE
Add retry with backoff for npm install in Bun Compile workflow

### DIFF
--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -52,7 +52,23 @@ jobs:
             echo "::error::No version provided. Supply via workflow_dispatch input or repository_dispatch payload."
             exit 1
           fi
-          bun install "@augmentcode/auggie@${VERSION}"
+          # Retry with backoff — npm registry may not have propagated the version yet
+          # when triggered immediately via repository_dispatch on publish.
+          max_attempts=5
+          for attempt in $(seq 1 $max_attempts); do
+            echo "Attempt $attempt/$max_attempts: installing @augmentcode/auggie@${VERSION}"
+            if bun install "@augmentcode/auggie@${VERSION}"; then
+              echo "Successfully installed on attempt $attempt"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              delay=$((attempt * 30))
+              echo "Install failed, retrying in ${delay}s..."
+              sleep "$delay"
+            fi
+          done
+          echo "::error::Failed to install @augmentcode/auggie@${VERSION} after $max_attempts attempts"
+          exit 1
 
       - name: Create entry point
         run: |


### PR DESCRIPTION
## Problem

The Bun Compile workflow [(run)](https://github.com/augmentcode/auggie/actions/runs/22975683047) failed because `bun install` couldn't find `@augmentcode/auggie@0.19.0-prerelease.10` — even though the version exists on npm. The `repository_dispatch` fires immediately on publish, but the npm registry hasn't fully propagated the new version yet.

## Fix

Adds a retry loop with linear backoff (5 attempts, 30s increments) to the install step. Retries at 30s, 60s, 90s, 120s — up to ~5 minutes total wait, which should comfortably handle npm CDN propagation delays.

In the happy path, the install succeeds on the first attempt with no delay.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author