### PR TITLE
Add common flags section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,21 @@ auggie "optional initial prompt"
 - Use `auggie --print "your instruction"` to run once and print to stdout (great for CI)
 - Add `--quiet` to return only the final output
 
+## Common flags
+
+| Flag | Description |
+| :--- | :---------- |
+| `-p, --print` | Run one instruction and print to stdout (non-interactive) |
+| `-q, --quiet` | Show only the final assistant message |
+| `-a, --ask` | Ask mode — retrieval and non-editing tools only |
+| `-m, --model <id>` | Select the model to use (`auggie model list` to see options) |
+| `-c, --continue` | Resume the most recent conversation |
+| `-r, --resume [id]` | Resume a specific session by ID or pick interactively |
+| `--rules <path>` | Additional rules file to append to workspace guidelines |
+| `--mcp-config <cfg>` | Path to MCP server configuration JSON |
+
+See the full [CLI reference](https://docs.augmentcode.com/cli/reference) for all flags and commands.
+
 ## Custom slash commands
 
 Store reusable prompts in `.augment/commands/` as markdown files with frontmatter. Once added, they’re available as slash commands (e.g., `/code-review path/to/file`).


### PR DESCRIPTION
## Summary

Adds a quick-reference table of commonly used CLI flags to the README. Many of these flags exist in the CLI but weren't mentioned in the README at all.

## Changes

Adds a "Common flags" section with a table covering:
- **Mode flags**: `-p/--print`, `-q/--quiet`, `-a/--ask`
- **Model selection**: `-m/--model`
- **Session management**: `-c/--continue`, `-r/--resume`
- **Configuration**: `--rules`, `--mcp-config`

Links to the full [CLI reference](https://docs.augmentcode.com/cli/reference) for complete details.

Note: BYOK flags (`--provider-model`, `--provider-api-key`, `--provider-base-url`) were intentionally excluded as they are not yet publicly available (gated to specific tenants in `flags.jsonnet`).

## Context

This was identified by scanning the CLI source code in `clients/cli/src/cli/arguments/` and comparing against the existing README, cross-referenced with `tools/feature_flags/flags.jsonnet` to confirm public availability.