### PR TITLE
docs: add changelog for cli@0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 - **MCP OAuth Paste Fallback**: Added a fallback option to paste the authentication code during MCP OAuth flows, simplifying setup in remote SSH environments.
 
 #### Improvements
-- **Cloud Agent Execution**: Added proper timeouts and graceful fail-safes for interactive tools in headless environments.
-- **Cloud Agent Status**: Improved granular status reporting for the cloud agent during execution.
 - **Plan Mode**: The chat transcript now remains visible when transitioning from plan mode to implementation.
 - **Plan Mode Sub-Agent**: Optimized execution by eliminating redundant output operations.
 - **`auggie command list`**: Output now consistently displays help text.
@@ -16,7 +14,6 @@
 - **Terminal Bell**: Now correctly rings when the agent is waiting for user input.
 
 #### Bug Fixes
-- Fixed an issue where the cloud agent queue would not correctly pause when interrupted mid-execution.
 - Fixed a bug where indexing could fail on extremely large repositories by falling back to a native Git approach.
 - Fixed an issue preventing custom plugin commands from being properly invoked via `auggie command`.
 - Fixed a visual bug where "Indexing complete" could incorrectly display multiple times at startup.


### PR DESCRIPTION
Add changelog entry for CLI version 0.21.0 to `CHANGELOG.md`.

### New Features
- **Automatic marketplace updates** — installed plugin marketplaces now update in the background, with prompts for workspace-recommended marketplaces
- **MCP OAuth paste fallback** — allow pasting the auth code during MCP OAuth flows for remote SSH environments

### Improvements
- Add timeouts and graceful fail-safes for cloud agent interactive tools in headless environments
- Improve granular status reporting during cloud agent execution
- Keep chat transcript visible when transitioning from plan mode to implementation
- Optimize plan mode sub-agent by eliminating redundant output operations
- Ensure `auggie command list` consistently displays help text
- Update startup login message for new users
- Fix terminal bell to ring when the agent awaits user input

### Bug Fixes
- Fix cloud agent queue not pausing correctly when interrupted mid-execution
- Fall back to native Git approach for indexing extremely large repositories
- Fix custom plugin commands not being invoked via `auggie command`
- Fix "Indexing complete" displaying multiple times at startup
- Fix CLI initialization hang when connecting to a stuck MCP server

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*