### PR TITLE
ci: pin Bun to 1.3.11 to fix codesign regression

### DIFF
--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
 
       - name: Install package
         env:


### PR DESCRIPTION
## Summary

Pins Bun to version 1.3.11 in the `bun-compile` workflow to fix the `codesign` failure on `darwin-arm64` binaries.

## Problem

Starting with [run #104](https://github.com/augmentcode/auggie/actions/runs/24255082888/job/70826819264), the "Sign binary" step consistently fails on `darwin-arm64` with:

```
auggie-darwin-arm64: invalid or unsupported format for signature
```

The workflow file had not changed — the breakage was caused by **Bun v1.3.12** (released April 9, 2026) being picked up automatically by `oven-sh/setup-bun@v2`. The previous run (#103) succeeded with Bun 1.3.11 just hours earlier.

Bun 1.3.12 includes a large JSC engine upgrade (1,650+ commits) and changes to standalone executable embedding that appear to have regressed the Mach-O layout of `bun build --compile --target=bun-darwin-arm64` output, making it unsignable by `codesign`.

## Fix

Pin `oven-sh/setup-bun@v2` to `bun-version: "1.3.11"` so the workflow uses a known-good Bun version.

## Verification

Manually triggered the workflow from this branch with version `0.24.0-prerelease.5` (the same version that failed on `main`) — all jobs passed, including `darwin-arm64` codesign and notarization.