### PR TITLE
docs: update changelog for v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,9 @@
 - **Image Support**: The view tool now supports displaying image files (PNG, JPG, GIF, WEBP).
 - **Context Stats**: Added `auggie context stats` command to display context and token usage information.
 - **JSON Output**: `auggie account status` now supports a `--json` flag for machine-readable output.
-- **Open in Browser**: Added `/web` slash command to open cloud sessions in a web browser.
 - **Terminal Title Control**: Added option to prevent the CLI from updating the terminal title.
-- **Worktree Isolation**: Cloud daemon child agents now use isolated git worktrees.
 
 #### Improvements
-- **Ask-User Overlay**: The ask-user prompt overlay is now resizable and shows a timeout countdown.
-- **Model Change Sync**: The CLI now reflects model changes made in the web app in real time.
-- **Git Context for Cloud Sessions**: Cloud sessions now receive git branch context at startup and detect live branch switches.
 - **Upgrade Handling**: `auggie upgrade` now correctly handles non-global npm installations.
 - **Conversation Memory**: Improved memory calculation to account for full agent state.
 
@@ -21,7 +16,6 @@
 - Fixed OAuth secrets not being cleaned up when an MCP server is removed.
 - Fixed duplicate MCP servers appearing in `/mcp list`.
 - Fixed TUI display glitches when resizing the terminal window.
-- Fixed cloud session reconnect command.
 
 ### 0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+### 0.24.0
+
+#### New Features
+- **Image Support**: The view tool now supports displaying image files (PNG, JPG, GIF, WEBP).
+- **Context Stats**: Added `auggie context stats` command to display context and token usage information.
+- **JSON Output**: `auggie account status` now supports a `--json` flag for machine-readable output.
+- **Open in Browser**: Added `/web` slash command to open cloud sessions in a web browser.
+- **Terminal Title Control**: Added option to prevent the CLI from updating the terminal title.
+- **Worktree Isolation**: Cloud daemon child agents now use isolated git worktrees.
+
+#### Improvements
+- **Ask-User Overlay**: The ask-user prompt overlay is now resizable and shows a timeout countdown.
+- **Model Change Sync**: The CLI now reflects model changes made in the web app in real time.
+- **Git Context for Cloud Sessions**: Cloud sessions now receive git branch context at startup and detect live branch switches.
+- **Upgrade Handling**: `auggie upgrade` now correctly handles non-global npm installations.
+- **Conversation Memory**: Improved memory calculation to account for full agent state.
+
+#### Bug Fixes
+- Fixed OAuth secrets not being cleaned up when an MCP server is removed.
+- Fixed duplicate MCP servers appearing in `/mcp list`.
+- Fixed TUI display glitches when resizing the terminal window.
+- Fixed cloud session reconnect command.
+
 ### 0.23.0
 
 #### New Features


### PR DESCRIPTION
Update release notes for v0.24.0 with the CLI, cloud session, and MCP changes included in this release.

- Document new capabilities for image previews, context usage stats, JSON account status output, terminal title control.
- Summarize usability and reliability improvements for ask-user prompts, model synchronization, git branch context, upgrade handling, and conversation memory calculation.
- Capture fixes for OAuth cleanup, duplicate MCP server listings, TUI resizing glitches.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*