### PR TITLE
ci: update V1_LATEST_TAG repo variable on stable releases

### DIFF
--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -159,3 +159,13 @@ jobs:
             $PRERELEASE_FLAG \
             artifacts/*
 
+      - name: Update V1_LATEST_TAG variable
+        if: ${{ !contains(inputs.version || github.event.client_payload.version, 'prerelease') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version || github.event.client_payload.version }}
+        run: |
+          gh api --method PATCH "repos/${{ github.repository }}/actions/variables/V1_LATEST_TAG" \
+            -f name="V1_LATEST_TAG" \
+            -f value="v${VERSION}"
+

--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -126,6 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      variables: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Problem

The hermes `release-auggie-v2` workflow publishes v2 releases to this repo and needs to restore "latest" back to the v1 stable release afterwards. It reads a repo variable (`V1_LATEST_TAG`) to know which tag to re-point to.

## Solution

After the bun-compile workflow creates a stable (non-prerelease) v1 release, update the `V1_LATEST_TAG` repo variable to the newly released version. This keeps the variable in sync automatically.

### Changes
- Added `variables: write` permission to the `release` job
- Added "Update V1_LATEST_TAG variable" step that runs only for stable releases

### Setup
- `V1_LATEST_TAG` repo variable has been created with initial value `v0.24.0`
- Verified the API call works via `gh api --method PATCH`

## Companion PR

- [hermes PR #176](https://github.com/augmentcode/hermes/pull/176) — reads `V1_LATEST_TAG` and re-points latest after each v2 release