### PR TITLE
fix(ci): use VARIABLES_WRITE_TOKEN for V1_LATEST_TAG update

### DIFF
--- a/.github/workflows/bun-compile.yml
+++ b/.github/workflows/bun-compile.yml
@@ -126,7 +126,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      variables: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -163,7 +162,7 @@ jobs:
       - name: Update V1_LATEST_TAG variable
         if: ${{ !contains(inputs.version || github.event.client_payload.version, 'prerelease') }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.VARIABLES_WRITE_TOKEN }}
           VERSION: ${{ inputs.version || github.event.client_payload.version }}
         run: |
           gh api --method PATCH "repos/${{ github.repository }}/actions/variables/V1_LATEST_TAG" \


### PR DESCRIPTION
## Summary

Fix stable releases so the `V1_LATEST_TAG` Actions repository variable can
actually be updated by the `release` job in `.github/workflows/bun-compile.yml`.

Two minimal workflow changes:

1. Remove the unsupported `variables: write` entry from the job's
   `permissions` block. There is no `variables` permission in GitHub
   Actions; its presence makes the release job definition invalid.
2. Switch the *Update V1_LATEST_TAG variable* step from the default
   `github.token` to `secrets.VARIABLES_WRITE_TOKEN`. The default
   `GITHUB_TOKEN` cannot modify Actions repository variables regardless
   of the `permissions` block.

## Root cause

`GITHUB_TOKEN` does not grant access to `PATCH /repos/{owner}/{repo}/actions/variables/{name}`.
The previous workflow attempted to compensate with
`permissions: variables: write`, which is not a real GitHub Actions
permission and therefore had no effect. As a result, the
`Update V1_LATEST_TAG variable` step in stable releases would always
fail to update the variable.

The supported approach for writing Actions variables is to authenticate
with a fine-grained PAT (or a GitHub App installation token) that has
explicit `Variables: read and write` access on the repository.

## Verification

- `git diff` reviewed: only the two intended lines change in
  `.github/workflows/bun-compile.yml` (+1 / -2).
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/bun-compile.yml'))"`
  parses successfully.
- `actionlint .github/workflows/bun-compile.yml` reports no findings.
- No other files modified.

End-to-end runtime verification (the variable actually being updated by
a real stable release run) requires the secret described in
**Required setup** to be present in repository settings. Provisioning
that secret is intentionally out of scope for this PR.

## Required setup

Before this workflow can update `V1_LATEST_TAG` end-to-end, the
following must be configured in `augmentcode/auggie` (out of band, not
in this PR):

- **Secret name:** `VARIABLES_WRITE_TOKEN`
- **Storage:** Repository Actions secret on `augmentcode/auggie`
  (Settings → Secrets and variables → Actions → Repository secrets).
  Organization-level or environment-level Actions secrets that are made
  available to this repository under the same name are also acceptable;
  do **not** store this token as an Actions *variable* or as a
  Dependabot/Codespaces secret.
- **Token type:** Fine-grained personal access token (PAT). A GitHub
  App installation token exposed via secret with the same scopes is an
  acceptable equivalent.
- **Resource owner:** `augmentcode`.
- **Repository access:** Only `augmentcode/auggie` (do not select
  "All repositories").
- **Repository permissions on the token:**
  - `Metadata`: **Read-only** (mandatory for any fine-grained PAT).
  - `Variables`: **Read and write**.
- No other permissions are required and none should be granted.

This PR does not provision, rotate, or reveal any token value.

## Out of scope

- Provisioning, rotating, or revealing the `VARIABLES_WRITE_TOKEN`
  secret value.
- Triggering a stable release.
- Mutating the `V1_LATEST_TAG` Actions variable.
- Any other workflow or repository changes.
