### PR TITLE
docs: update changelog for v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### 0.25.2
+
+#### New Features
+- **Custom Webhooks**: Expert builders can now configure typed custom webhooks for GitLab and Jira integrations.
+- **Chat Placeholder Text**: Expert configs now support a `placeholderText` field to customize the chat composer placeholder.
+
+#### Improvements
+- **Cosmos Branding**: Injected system-prompt rules now use the updated "Cosmos" branding.
+- **Backward Compatibility**: Added deprecated `--no-tui` alias to ensure smooth rollout for existing scripts.
+
+#### Bug Fixes
+- Fixed `auggie daemon` auth errors to be consistent with `auggie -p` behavior.
+- Fixed cloud expert prompt rendering for headless sessions.
+- Suppressed noisy setup logs during daemon early failures.
+
 ### 0.25.1
 
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,17 +71,11 @@
 
 ### 0.25.2
 
-#### New Features
-- **Custom Webhooks**: Expert builders can now configure typed custom webhooks for GitLab and Jira integrations.
-- **Chat Placeholder Text**: Expert configs now support a `placeholderText` field to customize the chat composer placeholder.
-
 #### Improvements
-- **Cosmos Branding**: Injected system-prompt rules now use the updated "Cosmos" branding.
-- **Backward Compatibility**: Added deprecated `--no-tui` alias to ensure smooth rollout for existing scripts.
+- **Backward Compatibility**: Added a deprecated `--no-tui` alias so existing scripts keep working.
 
 #### Bug Fixes
 - Fixed `auggie daemon` auth errors to be consistent with `auggie -p` behavior.
-- Fixed cloud expert prompt rendering for headless sessions.
 - Suppressed noisy setup logs during daemon early failures.
 
 ### 0.25.1


### PR DESCRIPTION
Update the changelog with release notes for `v0.25.2`.

- Add new feature notes for typed custom webhooks in GitLab and Jira integrations and configurable chat placeholder text in expert configs
- Document improvements to injected prompt branding and backward compatibility via the deprecated `--no-tui` alias
- Capture bug fixes for daemon auth consistency, headless cloud expert prompt rendering, and noisy daemon setup logs

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*