### PR TITLE
docs: update changelog for v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+### 0.26.0
+
+#### New Features
+- **PDF Attachments**: Added support for attaching PDF files to conversations.
+- **Expert Auto-Archive**: Expert YAML bundles now support an auto-archive setting for automatic session cleanup.
+- **Raw Codebase Retrieval**: New raw codebase retrieval tool for direct access to indexed code results.
+
+#### Improvements
+- **Daemon Version Display**: Daemon list and session details now show the CLI version running on each daemon.
+- **Better Entitlement Errors**: Improved error messages when daemon entitlement checks fail.
+- **Non-Interactive Mode Errors**: Permission errors are now surfaced earlier when running feature-gated commands in non-interactive mode.
+- **Removed Deprecated Commands**: Removed the deprecated Slack channel `claim` and `release` commands.
+
+#### Bug Fixes
+- Fixed cloud session sync failing when targeting a specific agent by ID.
+- Fixed Git PR and branch sync for worktree-based sessions.
+
 ### 0.25.1
 
 #### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,13 +74,11 @@
 #### New Features
 - **PDF Attachments**: Added support for attaching PDF files to conversations.
 - **Expert Auto-Archive**: Expert YAML bundles now support an auto-archive setting for automatic session cleanup.
-- **Raw Codebase Retrieval**: New raw codebase retrieval tool for direct access to indexed code results.
 
 #### Improvements
 - **Daemon Version Display**: Daemon list and session details now show the CLI version running on each daemon.
 - **Better Entitlement Errors**: Improved error messages when daemon entitlement checks fail.
 - **Non-Interactive Mode Errors**: Permission errors are now surfaced earlier when running feature-gated commands in non-interactive mode.
-- **Removed Deprecated Commands**: Removed the deprecated Slack channel `claim` and `release` commands.
 
 #### Bug Fixes
 - Fixed cloud session sync failing when targeting a specific agent by ID.


### PR DESCRIPTION
Update the v0.26.0 release notes to capture the latest user-facing features, improvements, and fixes.

- Add release notes for PDF conversation attachments, expert bundle auto-archive support, and raw codebase retrieval access
- Document operational and UX improvements, including daemon CLI version visibility, clearer entitlement and permission errors, and removal of deprecated Slack `claim`/`release` commands
- Record bug fixes for cloud session sync when targeting a specific agent ID and Git PR/branch sync in worktree-based sessions

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*