### PR TITLE
docs: update changelog for v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 0.28.0
+
+#### New Features
+- **General-Purpose Subagent**: Added a built-in general-purpose subagent option for broader multi-step research and implementation tasks.
+
+#### Improvements
+- **Model Defaults**: Added a configurable default model setting, and `/model` changes now apply only to the current session.
+- **Markdown Links**: The TUI now shows destination URLs for markdown links.
+- **Daemon Update Hints**: The app now warns when a connected daemon is out of date.
+- **Cloud Error Visibility**: Cloud sessions now surface CLI startup errors more directly in Cosmos.
+- **VFS Diagnostics**: VFS sync warnings and MCP merge collision errors now include clearer troubleshooting details.
+- **Lazy Skill Includes**: Lazy-loaded skill bodies can now include nested skills.
+
+#### Bug Fixes
+- Fixed cloud agents to retry transient knowledgebase sync failures and stop cleanly on unrecoverable errors.
+
 ### 0.27.0
 
 #### New Features


### PR DESCRIPTION
Update the release notes for `v0.28.0`.

- Add the new general-purpose subagent capability for broader multi-step research and implementation workflows.
- Document key usability and reliability improvements, including configurable default model behavior, visible markdown link destinations, daemon update warnings, clearer cloud startup errors, improved VFS diagnostics, and nested lazy skill includes.
- Note the cloud-agent fix for retrying transient knowledgebase sync failures and shutting down cleanly on unrecoverable errors.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*