### PR TITLE
docs: update changelog for v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - **Cloud Workflow Triggers**: `auggie cloud` experts can now use Jira, Confluence, GitLab, and Microsoft Teams as persistent workflow trigger sources.
 - **Session Space Pinning**: `auggie cloud session create` now accepts `--space-id` to pin a new session to a Space.
 - **VFS File Links**: Added `auggie cloud vfs get-url` to generate compact, durable links to VFS files.
-- **Daemon Diff View**: Added a diff view for the Auggie daemon.
 
 #### Improvements
 - **Daemon Worktree Directory**: `auggie daemon` can now be configured with a custom worktree directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 0.31.0
+
+#### New Features
+- **Cloud Workflow Triggers**: `auggie cloud` experts can now use Jira, Confluence, GitLab, and Microsoft Teams as persistent workflow trigger sources.
+- **Session Space Pinning**: `auggie cloud session create` now accepts `--space-id` to pin a new session to a Space.
+- **VFS File Links**: Added `auggie cloud vfs get-url` to generate compact, durable links to VFS files.
+- **Daemon Diff View**: Added a diff view for the Auggie daemon.
+
+#### Improvements
+- **Daemon Worktree Directory**: `auggie daemon` can now be configured with a custom worktree directory.
+
+#### Bug Fixes
+- Fixed `auggie cloud expert list --by-usage` to report weekly active users consistently with the webapp.
+- Fixed owner parity for opted-in shared MCP servers.
+- Fixed `${...}` variable expansion across MCP server and hook config files, including plugin-root variables.
+
 ### 0.30.0
 
 #### New Features


### PR DESCRIPTION
Update the changelog with v0.31.0 release notes so reviewers and users can quickly understand the release scope.

- Document new cloud workflow capabilities, including persistent triggers for Jira, Confluence, GitLab, and Microsoft Teams, Space pinning for cloud sessions, durable VFS file links, and a daemon diff view.
- Highlight the daemon worktree directory configuration improvement.
- Summarize fixes for expert usage reporting, shared MCP server owner parity, and `${...}` variable expansion across MCP server and hook configuration.

---
*🤖 This description was generated automatically. Please react with 👍 if it's helpful or 👎 if it needs improvement.*